### PR TITLE
[PDX-811] Add minimal `belongs_to` support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,14 @@
 PATH
   remote: .
   specs:
-    fv (0.0.1)
+    fv (0.2.0)
       activesupport
       httparty (~> 0.14.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.0.1)
+    activesupport (5.1.4)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (~> 0.7)
       minitest (~> 5.1)
@@ -23,9 +23,9 @@ GEM
     hashdiff (0.3.1)
     httparty (0.14.0)
       multi_xml (>= 0.5.2)
-    i18n (0.8.1)
+    i18n (0.8.6)
     method_source (0.8.2)
-    minitest (5.10.1)
+    minitest (5.10.3)
     multi_xml (0.6.0)
     pry (0.10.4)
       coderay (~> 1.1.0)
@@ -72,4 +72,4 @@ DEPENDENCIES
   webmock (~> 2.3.1)
 
 BUNDLED WITH
-   1.11.2
+   1.12.5

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ module MySdk
                              :attribute_b
 
     has_many :other_resources
+    belongs_to :related_thing
   end
 end
 ```
@@ -60,4 +61,5 @@ You're good to go!
 ```ruby
 my_resources = MySdk::MyResource.all
 my_resources.first.other_resources.first # MySdk::OtherResource
+my_resources.first.related_thing # MySdk::RelatedThing
 ```

--- a/lib/fv/version.rb
+++ b/lib/fv/version.rb
@@ -1,3 +1,3 @@
 module FV
-  VERSION = '0.1.0'
+  VERSION = '0.2.0'
 end

--- a/spec/fv/api_resource_spec.rb
+++ b/spec/fv/api_resource_spec.rb
@@ -212,9 +212,6 @@ describe FV::ApiResource do
       )
       expect(result).to be_a(TestSdk::FooBar)
     end
-
-    it 'saves association changes by hitting relationships url' do
-    end
   end
 
   module TestSdk

--- a/spec/fv/api_resource_spec.rb
+++ b/spec/fv/api_resource_spec.rb
@@ -193,9 +193,37 @@ describe FV::ApiResource do
     end
   end
 
+  describe '.belongs_to' do
+    before(:each) do
+      @resource = TestSdk::BelongsToResource.new(id: 1)
+    end
+
+    it 'creates method for accessing relationship' do
+      allow(TestSdk).to receive(:request).and_return(double(data: {}))
+
+      result = @resource.foo_bar
+
+      expect(TestSdk).to(
+        have_received(:request)
+          .with(
+            :get,
+            '/belongs_to_resources/1/foo_bar'
+          )
+      )
+      expect(result).to be_a(TestSdk::FooBar)
+    end
+
+    it 'saves association changes by hitting relationships url' do
+    end
+  end
+
   module TestSdk
     extend FV::Client
     class FooBar < FV::ApiResource
+    end
+
+    class BelongsToResource < FV::ApiResource
+      belongs_to :foo_bar
     end
 
     class Foo < FV::ApiResource


### PR DESCRIPTION
Adds the minimal necessary to support a read-only `belongs_to` decorator on resources.