### PR TITLE
Support saving attributes

### DIFF
--- a/lib/fv/api_resource.rb
+++ b/lib/fv/api_resource.rb
@@ -149,7 +149,7 @@ module FV
       response = self.class.client.request(
         :patch,
         path,
-        body: to_hash
+        body: to_hash.to_json
       )
       handle_new_data(response.data)
       self

--- a/lib/fv/api_resource.rb
+++ b/lib/fv/api_resource.rb
@@ -140,6 +140,14 @@ module FV
       serialized
     end
 
+    def to_json
+      {
+        id: @id,
+        type: self.class.resource_type,
+        attributes: @attributes
+      }.to_json
+    end
+
     def save
       @associations.each(&:save)
       @modified ? _save : self
@@ -149,7 +157,7 @@ module FV
       response = self.class.client.request(
         :patch,
         path,
-        body: to_hash.to_json
+        body: to_json
       )
       handle_new_data(response.data)
       self

--- a/lib/fv/api_resource.rb
+++ b/lib/fv/api_resource.rb
@@ -142,9 +142,11 @@ module FV
 
     def to_json
       {
-        id: @id,
-        type: self.class.resource_type,
-        attributes: @attributes
+        data: {
+          id: @id,
+          type: self.class.resource_type,
+          attributes: @attributes
+        }
       }.to_json
     end
 

--- a/spec/fv/api_resource_spec.rb
+++ b/spec/fv/api_resource_spec.rb
@@ -127,7 +127,8 @@ describe FV::ApiResource do
 
       resource = TestSdk::FooBar.new(
         id: 3,
-        attributes: { 'name' => 'original' }
+        attributes: { 'name' => 'original' },
+        meta: { stuff: 1 }
       )
       resource.name = 'changed'
       resource.save

--- a/spec/fv/api_resource_spec.rb
+++ b/spec/fv/api_resource_spec.rb
@@ -118,9 +118,11 @@ describe FV::ApiResource do
       allow_any_instance_of(FV::Client).to(
         receive(:request)
           .with(:patch, '/foo_bars/3', body: {
-            id: 3,
-            type: 'foo_bars',
-            attributes: { 'name' => 'changed' }
+            data: {
+              id: 3,
+              type: 'foo_bars',
+              attributes: { 'name' => 'changed' }
+            }
           }.to_json)
           .and_return(fake_response)
       )

--- a/spec/fv/api_resource_spec.rb
+++ b/spec/fv/api_resource_spec.rb
@@ -121,7 +121,7 @@ describe FV::ApiResource do
             id: 3,
             type: 'foo_bars',
             attributes: { 'name' => 'changed' }
-          })
+          }.to_json)
           .and_return(fake_response)
       )
 


### PR DESCRIPTION
Tracks modified attributes and sends updates to the server with a `PATCH` request when `save` is called on a resource.